### PR TITLE
Use net.FD.Read to fetch the sql connection info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ test/integration/components/go_otel_grpc/rolldice
 test/integration/components/pythonserver/lib/
 test/integration/components/pythonserver/lib64
 test/integration/components/pythonserver/pyvenv.cfg
+test/integration/components/gosql/qosql

--- a/bpf/go_nethttp.h
+++ b/bpf/go_nethttp.h
@@ -912,17 +912,41 @@ int uprobe_netFdRead(struct pt_regs *ctx) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
 
+    // lookup active HTTP connection
     connection_info_t *conn = bpf_map_lookup_elem(&ongoing_server_connections, &g_key);
-
     if (conn) {
-        bpf_dbg_printk(
-            "Found existing server connection, parsing FD information for socket tuples, %llx",
-            goroutine_addr);
+        if (conn->d_port == 0 && conn->s_port == 0) {
+            bpf_dbg_printk(
+                "Found existing server connection, parsing FD information for socket tuples, %llx",
+                goroutine_addr);
 
-        void *fd_ptr = GO_PARAM1(ctx);
-        get_conn_info_from_fd(fd_ptr, conn); // ok to not check the result, we leave it as 0
-
+            void *fd_ptr = GO_PARAM1(ctx);
+            get_conn_info_from_fd(fd_ptr, conn); // ok to not check the result, we leave it as 0
+        }
         //dbg_print_http_connection_info(conn);
+    }
+    // lookup a grpc connection
+    // Sets up the connection info to be grabbed and mapped over the transport to operateHeaders
+    void *tr = bpf_map_lookup_elem(&ongoing_grpc_operate_headers, &g_key);
+    bpf_dbg_printk("tr %llx", tr);
+    if (tr) {
+        grpc_transports_t *t = bpf_map_lookup_elem(&ongoing_grpc_transports, tr);
+        bpf_dbg_printk("t %llx", t);
+        if (t) {
+            if (t->conn.d_port == 0 && t->conn.s_port == 0) {
+                void *fd_ptr = GO_PARAM1(ctx);
+                get_conn_info_from_fd(fd_ptr,
+                                      &t->conn); // ok to not check the result, we leave it as 0
+            }
+        }
+    }
+    // lookup active sql connection
+    sql_func_invocation_t *sql_conn = bpf_map_lookup_elem(&ongoing_sql_queries, &g_key);
+    bpf_dbg_printk("sql_conn %llx", sql_conn);
+    if (sql_conn) {
+        void *fd_ptr = GO_PARAM1(ctx);
+        get_conn_info_from_fd(fd_ptr,
+                              &sql_conn->conn); // ok to not check the result, we leave it as 0
     }
 
     return 0;

--- a/bpf/go_sql.h
+++ b/bpf/go_sql.h
@@ -26,25 +26,11 @@
 #include "go_common.h"
 #include "ringbuf.h"
 
-typedef struct sql_func_invocation {
-    u64 start_monotime_ns;
-    u64 sql_param;
-    u64 query_len;
-    connection_info_t conn __attribute__((aligned(8)));
-    tp_info_t tp;
-} sql_func_invocation_t;
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, go_addr_key_t); // key: pointer to the request goroutine
-    __type(value, sql_func_invocation_t);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-} ongoing_sql_queries SEC(".maps");
-
 static __always_inline void set_sql_info(void *goroutine_addr, void *sql_param, void *query_len) {
     sql_func_invocation_t invocation = {.start_monotime_ns = bpf_ktime_get_ns(),
                                         .sql_param = (u64)sql_param,
                                         .query_len = (u64)query_len,
+                                        .conn = {0},
                                         .tp = {0}};
 
     // We don't look up in the headers, no http/grpc request, therefore 0 as last argument
@@ -66,42 +52,6 @@ int uprobe_queryDC(struct pt_regs *ctx) {
 
     void *sql_param = GO_PARAM8(ctx);
     void *query_len = GO_PARAM9(ctx);
-
-    off_table_t *ot = get_offsets_table();
-    go_addr_key_t g_key = {};
-    go_addr_key_from_id(&g_key, goroutine_addr);
-
-    connection_info_t *existing = bpf_map_lookup_elem(&ongoing_server_connections, &g_key);
-
-    if (!existing) {
-        void *c_ptr = GO_PARAM1(ctx);
-        if (c_ptr) {
-            void *conn_conn_ptr =
-                c_ptr + 8 + go_offset_of(ot, (go_offset){.v = _c_rwc_pos}); // embedded struct
-            void *tls_state = 0;
-            bpf_probe_read(&tls_state,
-                           sizeof(tls_state),
-                           (void *)(c_ptr + go_offset_of(ot, (go_offset){.v = _c_tls_pos})));
-            conn_conn_ptr = unwrap_tls_conn_info(conn_conn_ptr, tls_state);
-            //bpf_dbg_printk("conn_conn_ptr %llx, tls_state %llx, c_tls_pos = %d, c_tls_ptr = %llx", conn_conn_ptr, tls_state, c_tls_pos, c_ptr + c_tls_pos);
-            if (conn_conn_ptr) {
-                void *conn_ptr = 0;
-                bpf_probe_read(
-                    &conn_ptr,
-                    sizeof(conn_ptr),
-                    (void *)(conn_conn_ptr +
-                             go_offset_of(ot, (go_offset){.v = _net_conn_pos}))); // find conn
-                bpf_dbg_printk("conn_ptr %llx", conn_ptr);
-                if (conn_ptr) {
-                    connection_info_t conn = {0};
-                    get_conn_info(
-                        conn_ptr,
-                        &conn); // initialized to 0, no need to check the result if we succeeded
-                    bpf_map_update_elem(&ongoing_server_connections, &g_key, &conn, BPF_ANY);
-                }
-            }
-        }
-    }
 
     set_sql_info(goroutine_addr, sql_param, query_len);
     return 0;
@@ -156,20 +106,7 @@ int uprobe_queryReturn(struct pt_regs *ctx) {
             trace->sql[query_len] = 0;
         }
 
-        connection_info_t *info = bpf_map_lookup_elem(&ongoing_server_connections, &g_key);
-
-        if (info) {
-            //dbg_print_http_connection_info(info);
-            __builtin_memcpy(&trace->conn, info, sizeof(connection_info_t));
-        } else {
-            // We can't find the connection info, this typically means there are too many requests per second
-            // and the connection map is too small for the workload.
-            bpf_dbg_printk("Can't find connection info for %llx", goroutine_addr);
-            __builtin_memset(&trace->conn, 0, sizeof(connection_info_t));
-        }
-
-        // Server connections have opposite order, source port is the server port
-        swap_connection_info_order(&trace->conn);
+        __builtin_memcpy(&trace->conn, &invocation->conn, sizeof(connection_info_t));
 
         // submit the completed trace via ringbuffer
         bpf_ringbuf_submit(trace, get_flags());

--- a/pkg/internal/ebpf/common/bpf_arm64_bpfel.o
+++ b/pkg/internal/ebpf/common/bpf_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b73865e52c411d74a5fb8b419c9ed7480c36f905e63dcc553ccba7b7ea6bb4ff
-size 4416
+oid sha256:34d534081f766ad8d8e1ad3aa023b0160c094ad8169e0749992b08521734b822
+size 4432

--- a/pkg/internal/ebpf/common/bpf_x86_bpfel.o
+++ b/pkg/internal/ebpf/common/bpf_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b73865e52c411d74a5fb8b419c9ed7480c36f905e63dcc553ccba7b7ea6bb4ff
-size 4416
+oid sha256:34d534081f766ad8d8e1ad3aa023b0160c094ad8169e0749992b08521734b822
+size 4432

--- a/pkg/internal/ebpf/gotracer/bpf_arm64_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_arm64_bpfel.go
@@ -229,7 +229,6 @@ type bpfProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -412,7 +411,6 @@ type bpfPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -468,7 +466,6 @@ func (p *bpfPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_arm64_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:071123225984f9740cd1fb793bd6dc642bb8086c6d4ffdf255983c72d9d769a8
-size 391560
+oid sha256:eff29edf6c7d97295378a49172e306b0a9f269f8d03b062bbebe7ea7e001b365
+size 398120

--- a/pkg/internal/ebpf/gotracer/bpf_debug_arm64_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_debug_arm64_bpfel.go
@@ -229,7 +229,6 @@ type bpf_debugProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -415,7 +414,6 @@ type bpf_debugPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -471,7 +469,6 @@ func (p *bpf_debugPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_debug_arm64_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_debug_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:111be7bb730eaeda13976aab671d34f6c61b3cecdfc57ac93e0c737e2c876922
-size 877992
+oid sha256:9dbfb1ba005c60f0b29fe9cbf8544d6e8146c26907865f0225c33f872d8c7881
+size 885760

--- a/pkg/internal/ebpf/gotracer/bpf_debug_x86_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_debug_x86_bpfel.go
@@ -229,7 +229,6 @@ type bpf_debugProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -415,7 +414,6 @@ type bpf_debugPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -471,7 +469,6 @@ func (p *bpf_debugPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_debug_x86_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_debug_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f3edc0530c9670e71ba790450de591c938685c2dce61ab67618b0ae098be83e
-size 879824
+oid sha256:d9e9be61b2385d2b03d899fcc7c3d5c9e61fa1cfb424592c2411abbcd21b4afc
+size 887592

--- a/pkg/internal/ebpf/gotracer/bpf_tp_arm64_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_arm64_bpfel.go
@@ -241,7 +241,6 @@ type bpf_tpProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -436,7 +435,6 @@ type bpf_tpPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -492,7 +490,6 @@ func (p *bpf_tpPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_tp_arm64_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:229e3c5cd2ee5e79bb620ed1e9f550cee7a053ccf996d4d4eadbeb4dfea4ca0c
-size 438160
+oid sha256:9c4fbfd08163575e0f9d525b725e8ba5b1c8c39b01b2af549ae3098873b4736c
+size 444720

--- a/pkg/internal/ebpf/gotracer/bpf_tp_debug_arm64_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_debug_arm64_bpfel.go
@@ -241,7 +241,6 @@ type bpf_tp_debugProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -439,7 +438,6 @@ type bpf_tp_debugPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -495,7 +493,6 @@ func (p *bpf_tp_debugPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_tp_debug_arm64_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_debug_arm64_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3fef143984a45c24843bf1d525db1a0da704f3a3d40b21d12f7320521cb2233
-size 975920
+oid sha256:1ff2e0f5ee2a31b1afbc37497fc0eebc1c995847df7dc11a0c889b21f292cdc7
+size 983680

--- a/pkg/internal/ebpf/gotracer/bpf_tp_debug_x86_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_debug_x86_bpfel.go
@@ -241,7 +241,6 @@ type bpf_tp_debugProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -439,7 +438,6 @@ type bpf_tp_debugPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -495,7 +493,6 @@ func (p *bpf_tp_debugPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_tp_debug_x86_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_debug_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58d88ce943d9b8efe56ba6f92af83a9c3c6cd263a61d8a4bddba41bbed8a83c5
-size 977744
+oid sha256:991c59999e1b34fad4fb85daf91a0bec4c04ef7f3cd9f35d1249f80b117327ce
+size 985504

--- a/pkg/internal/ebpf/gotracer/bpf_tp_x86_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_x86_bpfel.go
@@ -241,7 +241,6 @@ type bpf_tpProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -436,7 +435,6 @@ type bpf_tpPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -492,7 +490,6 @@ func (p *bpf_tpPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_tp_x86_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_tp_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a24461d952bb1600eb072e7f53826042aa80bdef774520dd431fd8daa50bd1aa
-size 439920
+oid sha256:795a1d9533f2f3b0671d253f7a7cdcaa035f247952e0515ec2eea9a7e88d8d29
+size 446480

--- a/pkg/internal/ebpf/gotracer/bpf_x86_bpfel.go
+++ b/pkg/internal/ebpf/gotracer/bpf_x86_bpfel.go
@@ -229,7 +229,6 @@ type bpfProgramSpecs struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.ProgramSpec `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.ProgramSpec `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.ProgramSpec `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.ProgramSpec `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.ProgramSpec `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.ProgramSpec `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.ProgramSpec `ebpf:"uprobe_proc_newproc1"`
@@ -412,7 +411,6 @@ type bpfPrograms struct {
 	UprobeHttp2ServerOperateHeaders           *ebpf.Program `ebpf:"uprobe_http2Server_operateHeaders"`
 	UprobeHttp2serverConnRunHandler           *ebpf.Program `ebpf:"uprobe_http2serverConn_runHandler"`
 	UprobeNetFdRead                           *ebpf.Program `ebpf:"uprobe_netFdRead"`
-	UprobeNetFdReadGRPC                       *ebpf.Program `ebpf:"uprobe_netFdReadGRPC"`
 	UprobePersistConnRoundTrip                *ebpf.Program `ebpf:"uprobe_persistConnRoundTrip"`
 	UprobeProcGoexit1                         *ebpf.Program `ebpf:"uprobe_proc_goexit1"`
 	UprobeProcNewproc1                        *ebpf.Program `ebpf:"uprobe_proc_newproc1"`
@@ -468,7 +466,6 @@ func (p *bpfPrograms) Close() error {
 		p.UprobeHttp2ServerOperateHeaders,
 		p.UprobeHttp2serverConnRunHandler,
 		p.UprobeNetFdRead,
-		p.UprobeNetFdReadGRPC,
 		p.UprobePersistConnRoundTrip,
 		p.UprobeProcGoexit1,
 		p.UprobeProcNewproc1,

--- a/pkg/internal/ebpf/gotracer/bpf_x86_bpfel.o
+++ b/pkg/internal/ebpf/gotracer/bpf_x86_bpfel.o
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bf98c268e2dc35a9bdd74152f3b4b8f7e739df8b2ed1cdf6eb6d1681c0892c0
-size 393392
+oid sha256:6e68460db9ca75b69d56d154c3d8564ba6ef359432a002f9b51524379cddcfee
+size 399952

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -227,9 +227,6 @@ func (p *Tracer) GoProbes() map[string][]ebpfcommon.FunctionPrograms {
 			{
 				Start: p.bpfObjects.UprobeNetFdRead,
 			},
-			{ // for grpc
-				Start: p.bpfObjects.UprobeNetFdReadGRPC,
-			},
 		},
 		"net/http.(*persistConn).roundTrip": {{ // http client
 			Start: p.bpfObjects.UprobePersistConnRoundTrip,

--- a/test/integration/components/gosql/Dockerfile
+++ b/test/integration/components/gosql/Dockerfile
@@ -1,0 +1,27 @@
+# Build the testserver binary
+# Docker command must be invoked from the projec root directory
+FROM golang:1.23 AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# Copy the go manifests and source
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY gosql.go gosql.go
+
+# Build
+RUN go mod download
+RUN go build -o qosql gosql.go
+
+# Create final image from minimal + built binary
+FROM debian:bookworm-slim
+
+WORKDIR /
+COPY --from=builder /src/gosql .
+USER 0:0
+
+CMD [ "/qosql" ]

--- a/test/integration/components/gosql/go.mod
+++ b/test/integration/components/gosql/go.mod
@@ -1,0 +1,7 @@
+module github.com/beyla/test/integration/components/gosql
+
+go 1.21
+
+toolchain go1.23.0
+
+require github.com/lib/pq v1.10.9

--- a/test/integration/components/gosql/go.sum
+++ b/test/integration/components/gosql/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/test/integration/components/gosql/gosql.go
+++ b/test/integration/components/gosql/gosql.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	psqlInit := false
+	var db *sql.DB
+	var err error
+
+	http.HandleFunc("/psqltest", func(w http.ResponseWriter, r *http.Request) {
+		if !psqlInit {
+			db, err = sql.Open("postgres", "user=postgres dbname=sqltest sslmode=disable password=postgres host=localhost port=5432")
+			if err != nil {
+				log.Fatal(err)
+			}
+			psqlInit = true
+		}
+		// Ping the database to verify the connection
+		err = db.Ping()
+		if err != nil {
+			log.Printf("%v\n", err)
+			w.WriteHeader(500)
+			return
+		}
+
+		// Execute a query
+		rows, err := db.Query("SELECT * from accounting.contacts WHERE id=1")
+		if err != nil {
+			log.Printf("%v\n", err)
+			w.WriteHeader(500)
+			return
+		}
+		defer rows.Close()
+
+		var name, lastNames, address string
+		var id int
+
+		if rows.Next() {
+			err = rows.Scan(&id, &name, &lastNames, &address)
+			if err != nil {
+				log.Printf("%v\n", err)
+				w.WriteHeader(500)
+				return
+			}
+			fmt.Println("name: ", name, " id: ", id)
+		} else {
+			log.Printf("no data", err)
+			w.WriteHeader(500)
+			return
+		}
+
+		w.Write([]byte(name + " " + lastNames))
+	})
+
+	err = http.ListenAndServe(":8080", nil)
+	if db != nil {
+		db.Close()
+	}
+}


### PR DESCRIPTION
Pulling the connection information for an outgoing sql request is driver dependent, but then I remembered that eventually the Go SDK will have to boil down to net.FD.Read, because all sockets are files. So I added code in net.FD.Read to consider also the SQL connections and I was able to track what's happening.

Please let me know if this is acceptable and it works for you and then it's a matter of adding a new integration test for the Go sql example I added, which uses our Postgres test db.